### PR TITLE
Add keystone openid auth

### DIFF
--- a/roles/horizon/defaults/main.yml
+++ b/roles/horizon/defaults/main.yml
@@ -6,6 +6,11 @@ horizon_physical_networks:
   - provider
 horizon_session_timeout: 3600
 
+horizon_openid_providers: []
+  # - name: myopenid
+  #   display_name: My OpenID
+horizon_openid_logout_url: "{{keystone_public_url}}/v3/auth/OS-FEDERATION/websso/openid?session=logout&logout=https://{{horizon_allowed_hosts[0]}}/dashboard/auth/logout/"
+horizon_websso_default: credentials
 
 # customize the dashboard: https://docs.openstack.org/horizon/latest/admin/customize-configure.html
 horizon_customize_site_branding: ~ # Example, Inc. Cloud

--- a/roles/horizon/templates/local_settings.py.j2
+++ b/roles/horizon/templates/local_settings.py.j2
@@ -20,6 +20,22 @@ CACHES = {
          'LOCATION': '{{memcached_host}}:11211',
     }
 }
+{% if horizon_openid_providers | length > 0 %}
+WEBSSO_ENABLED = True
+WEBSSO_INITIAL_CHOICE = "{{horizon_websso_default}}"
+WEBSSO_CHOICES = (
+    ("credentials", _("Keystone Credentials")),
+{% for provider in horizon_openid_providers %}
+    ("openid_{{provider.name}}", _("{{provider.display_name}}")),
+{% endfor %}
+)
+WEBSSO_IDP_MAPPING = {
+{% for provider in horizon_openid_providers %}
+    "openid_{{provider.name}}": ("{{provider.name}}", "openid"),
+{% endfor %}
+}
+LOGOUT_URL = "{{horizon_openid_logout_url}}"
+{% endif %}
 OPENSTACK_API_VERSIONS = {
     "identity": 3,
     "image": 2,

--- a/roles/keystone/defaults/main.yml
+++ b/roles/keystone/defaults/main.yml
@@ -15,6 +15,30 @@ keystone_freeipa_servers: []
   #   user_filter: (memberof=cn=openstack-users,cn=groups,cn=accounts,dc=example,dc=com)
   #   group_filter: ""
 
+keystone_openid_crypto_passphrase: "{{secrets_openid_secret}}"
+keystone_openid_providers: []
+  # - name: myopenid
+  #   client_id: openstack
+  #   client_secret: secret
+  #   domain: myopenid
+  #   metadata_url: https://keycloak.example.com/auth/realms/admin/.well-known/openid-configuration
+  #   issuer: https://keycloak.example.com/auth/realms/admin
+  #   # examples: https://docs.openstack.org/keystone/latest/admin/federation/mapping_combinations.html
+  #   mapping_rules:
+  #     - local:
+  #         - user:
+  #             name: "{0}"
+  #             email: "{1}"
+  #         - groups: "{2}"
+  #           domain:
+  #             name: myopenid
+  #       remote:
+  #         - type: OIDC-preferred_username
+  #         - type: OIDC-email
+  #         - type: OIDC-groups
+
+keystone_federation_trusted_dashboard_hosts: "{{horizon_allowed_hosts}}"
+
 keystone_admin_auth:
   auth_url: "{{keystone_url}}/v3"
   username: admin

--- a/roles/keystone/defaults/main.yml
+++ b/roles/keystone/defaults/main.yml
@@ -28,7 +28,7 @@ keystone_service_endpoint_interfaces:
   - internal
   - admin
 
-keystone_service_internal_url: {}
+keystone_service_public_url: {}
   # <service_name>: <url>
 keystone_service_admin_url: {}
   # <service_name>: <url>

--- a/roles/keystone/handlers/main.yml
+++ b/roles/keystone/handlers/main.yml
@@ -11,7 +11,7 @@
 - name: bootstrap keystone
   shell: |
     keystone-manage bootstrap --bootstrap-password {{keystone_admin_password}} \
-      --bootstrap-admin-url {{keystone_url}}/v3/ \
-      --bootstrap-internal-url {{keystone_internal_url}}/v3/ \
+      --bootstrap-internal-url {{keystone_url}}/v3/ \
+      --bootstrap-admin-url {{keystone_admin_url}}/v3/ \
       --bootstrap-public-url {{keystone_public_url}}/v3/ \
       --bootstrap-region-id {{keystone_bootstrap_region}}

--- a/roles/keystone/tasks/main.yml
+++ b/roles/keystone/tasks/main.yml
@@ -19,6 +19,18 @@
     - init keystone db
     - restart httpd
 
+- name: install httpd openidc auth mod
+  dnf:
+    name: "@mod_auth_openidc/default"
+  when: keystone_openid_providers | length > 0
+  notify: restart httpd
+
+- name: create openid metadata directory
+  file:
+    path: /etc/httpd/mod_auth_openidc
+    state: directory
+  when: keystone_openid_providers | length > 0
+
 - name: configure
   template:
     src: keystone.conf.j2
@@ -67,6 +79,8 @@
   template:
     src: wsgi-keystone.conf.j2
     dest: /etc/httpd/conf.d/wsgi-keystone.conf
+    group: apache
+    mode: 0640
   notify: restart httpd
 
 - name: flush handlers
@@ -105,3 +119,11 @@
   loop: "{{keystone_freeipa_servers}}"
   loop_control:
     label: "{{item.domain}}"
+
+- name: configure openid providers
+  include_tasks: openid_provider.yml
+  loop: "{{keystone_openid_providers}}"
+  loop_control:
+    loop_var: provider
+    label: "{{provider.name}}"
+  when: keystone_openid_providers | length > 0

--- a/roles/keystone/tasks/main.yml
+++ b/roles/keystone/tasks/main.yml
@@ -28,6 +28,7 @@
     - init keystone db
     - init keystone token provider
     - bootstrap keystone
+    - restart httpd
 
 - name: create directory for domain configurations
   file:

--- a/roles/keystone/tasks/openid_provider.yml
+++ b/roles/keystone/tasks/openid_provider.yml
@@ -1,0 +1,54 @@
+- name: "create openid client metadata for {{provider.name}}"
+  copy:
+    content: |
+      {
+        "client_id": "{{provider.client_id}}",
+        "client_secret": "{{provider.client_secret}}"
+      }
+    dest: "/etc/httpd/mod_auth_openidc/{{provider.issuer | urlsplit('hostname')}}{{provider.issuer | urlsplit('path') | replace('/', '%2F')}}.client"
+    group: apache
+    mode: 0640
+
+- name: "create openid config metadata for {{provider.name}}"
+  copy:
+    content: |
+      {}
+    dest: "/etc/httpd/mod_auth_openidc/{{provider.issuer | urlsplit('hostname')}}{{provider.issuer | urlsplit('path') | replace('/', '%2F')}}.conf"
+
+- name: "create openid provider metadata for {{provider.name}}"
+  get_url:
+    url: "{{provider.metadata_url}}"
+    dest: "/etc/httpd/mod_auth_openidc/{{provider.issuer | urlsplit('hostname')}}{{provider.issuer | urlsplit('path') | replace('/', '%2F')}}.provider"
+
+- name: "create openid domain for {{provider.name}}"
+  openstack.cloud.identity_domain:
+    auth: "{{keystone_admin_auth}}"
+    name: "{{provider.domain}}"
+    description: "OpenID {{provider.domain}}"
+
+- name: "get info about openid domain for {{provider.name}}"
+  openstack.cloud.identity_domain_info:
+    auth: "{{keystone_admin_auth}}"
+    name: "{{provider.domain}}"
+  register: openid_provider_domain
+
+- name: "create openid identity provider for {{provider.name}}"
+  openstack.cloud.federation_idp:
+    auth: "{{keystone_admin_auth}}"
+    name: "{{provider.name}}"
+    domain_id: "{{openid_provider_domain.openstack_domains[0].id}}"
+    remote_ids:
+      - "{{provider.issuer}}"
+
+- name: "create openid mapping rules for {{provider.name}}"
+  openstack.cloud.federation_mapping:
+    auth: "{{keystone_admin_auth}}"
+    name: "{{provider.name}}_mapping"
+    rules: "{{provider.mapping_rules}}"
+
+- name: "create openid federation protocol for {{provider.name}}"
+  openstack.cloud.keystone_federation_protocol:
+    auth: "{{keystone_admin_auth}}"
+    name: openid
+    idp_id: "{{provider.name}}"
+    mapping_id: "{{provider.name}}_mapping"

--- a/roles/keystone/templates/keystone.conf.j2
+++ b/roles/keystone/templates/keystone.conf.j2
@@ -13,3 +13,16 @@ expiration = {{keystone_token_expiration}}
 [identity]
 domain_specific_drivers_enabled = True
 domain_config_dir = /etc/keystone/domains
+{% if keystone_openid_providers | length > 0 %}
+
+[auth]
+methods = password,token,openid
+
+[federation]
+{% for host in keystone_federation_trusted_dashboard_hosts %}
+trusted_dashboard = https://{{host}}/dashboard/auth/websso/
+{% endfor %}
+
+[openid]
+remote_id_attribute = HTTP_OIDC_ISS
+{% endif %}

--- a/roles/keystone/templates/wsgi-keystone.conf.j2
+++ b/roles/keystone/templates/wsgi-keystone.conf.j2
@@ -38,3 +38,41 @@ Alias /identity /usr/bin/keystone-wsgi-public
     WSGIApplicationGroup %{GLOBAL}
     WSGIPassAuthorization On
 </Location>
+{% if keystone_openid_providers | length > 0 %}
+
+OIDCClaimPrefix "OIDC-"
+OIDCResponseType id_token
+OIDCScope "openid email profile"
+OIDCCryptoPassphrase {{keystone_openid_crypto_passphrase}}
+OIDCRedirectURI /v3/auth/OS-FEDERATION/websso/openid
+OIDCProviderTokenEndpointAuth client_secret_basic
+OIDCRemoteUserClaim email
+OIDCClaimDelimiter ";"
+OIDCMetadataDir /etc/httpd/mod_auth_openidc
+OIDCDiscoverURL /oidc-discover
+
+{% for provider in keystone_openid_providers %}
+# {{provider.name}} openid provider
+<Location /v3/OS-FEDERATION/identity_providers/{{provider.name}}/protocols/openid/auth>
+    AuthType openid-connect
+    Require valid-user
+</Location>
+
+<Location /v3/auth/OS-FEDERATION/identity_providers/{{provider.name}}/protocols/openid/websso>
+    AuthType openid-connect
+    Require valid-user
+</Location>
+
+{% endfor %}
+<Location /v3/auth/OS-FEDERATION/websso/openid>
+    AuthType openid-connect
+    Require valid-user
+</Location>
+
+<Location /oidc-discover>
+{% for provider in keystone_openid_providers %}
+    RewriteCond %{QUERY_STRING} target_link_uri=[^&]*identity_providers%2F{{provider.name}}%2F[^&]*
+    RewriteRule ^(.*)$ /v3/auth/OS-FEDERATION/websso/openid?%{QUERY_STRING}&iss={{provider.issuer}} [R=302,NE,L]
+{% endfor %}
+</Location>
+{% endif %}

--- a/roles/neutron/tasks/main.yml
+++ b/roles/neutron/tasks/main.yml
@@ -8,7 +8,7 @@
       - openstack-neutron
       - openstack-neutron-ml2
       - net-tools
-    state: "{{package_state | default('present')}}"
+    state: "{{package_state | default('present')}}"
   when: is_controller_node or is_network_node
   notify:
     - init neutron db
@@ -23,14 +23,14 @@
       - openstack-neutron-linuxbridge
       - ebtables
       - ipset
-    state: "{{package_state | default('present')}}"
+    state: "{{package_state | default('present')}}"
   notify: restart neutron-linuxbridge-agent
   when: is_network_node or is_compute_node
 
 - name: install sriov-nic agent
   package:
     name: openstack-neutron-sriov-nic-agent
-    state: "{{package_state | default('present')}}"
+    state: "{{package_state | default('present')}}"
   notify: restart neutron-linuxbridge-agent
   when: (is_network_node or is_compute_node)
         and neutron_sriov_agent
@@ -38,7 +38,7 @@
 - name: install vpnaas plugin
   package:
     name: openstack-neutron-vpnaas
-    state: "{{package_state | default('present')}}"
+    state: "{{package_state | default('present')}}"
   notify:
     - init neutron db
     - restart neutron-server

--- a/secrets.yml.j2
+++ b/secrets.yml.j2
@@ -18,6 +18,8 @@ secrets_glance_pass: "{{ secrets_glance_pass | default(lookup('password', '/dev/
 secrets_keystone_dbpass: "{{ secrets_keystone_dbpass | default(lookup('password', '/dev/null chars=ascii_letters,digits')) }}"
 # LDAP password of Identity service
 secrets_ldap_pass: "{{ secrets_ldap_pass | default(lookup('password', '/dev/null chars=ascii_letters,digits')) }}"
+# OpenID crypto passphrase for Identity service
+secrets_openid_secret: "{{ secrets_openid_secret | default(lookup('password', '/dev/null chars=ascii_letters,digits')) }}"
 # Secret for the metadata proxy
 secrets_metadata_secret: "{{ secrets_metadata_secret | default(lookup('password', '/dev/null chars=ascii_letters,digits')) }}"
 # Database password for the Networking service


### PR DESCRIPTION
Adds OpenID support for keystone. Currently only tested with Keycloak as identity provider.