### PR TITLE
fix deprecated ansible command warn arg

### DIFF
--- a/roles/cinder/handlers/main.yml
+++ b/roles/cinder/handlers/main.yml
@@ -1,15 +1,11 @@
 - name: init cinder db
   shell: su -s /bin/sh -c "cinder-manage db sync" cinder
-  args:
-    warn: false
   when: is_controller_node
 
 - name: define cinder ceph secret
   shell: |
     virsh secret-define --file /etc/ceph/libvirt_cinder_ceph.xml
     virsh secret-set-value --secret {{cinder_rbd_secret_uuid}} --base64 {{cinder_rbd_client_key.content | b64decode | regex_search('[A-Za-z0-9\/+]+==', multiline=True)}}
-  args:
-    warn: false
   when: is_compute_node
 
 - name: restart cinder-api

--- a/roles/designate/handlers/main.yml
+++ b/roles/designate/handlers/main.yml
@@ -1,7 +1,5 @@
 - name: init designate db
   shell: su -s /bin/sh -c "designate-manage database sync" designate
-  args:
-    warn: false
 
 - name: restart named
   systemd:
@@ -35,5 +33,3 @@
 
 - name: init designate pools
   shell: su -s /bin/sh -c "designate-manage pool update" designate
-  args:
-    warn: false

--- a/roles/glance/handlers/main.yml
+++ b/roles/glance/handlers/main.yml
@@ -1,14 +1,12 @@
 - name: init glance db
   shell: su -s /bin/sh -c "glance-manage db_sync" glance
-  args:
-    warn: false
 
 - name: restart glance-registry
   systemd:
     name: openstack-glance-registry
     state: restarted
   when: ansible_distribution_major_version|int < 8
-  
+
 - name: restart glance-api
   systemd:
     name: openstack-glance-api

--- a/roles/heat/handlers/main.yml
+++ b/roles/heat/handlers/main.yml
@@ -1,7 +1,5 @@
 - name: init heat db
   shell: su -s /bin/sh -c "heat-manage db_sync" heat
-  args:
-    warn: false
 
 - name: restart heat-api
   systemd:

--- a/roles/keystone/handlers/main.yml
+++ b/roles/keystone/handlers/main.yml
@@ -1,7 +1,5 @@
 - name: init keystone db
   shell: su -s /bin/sh -c "keystone-manage db_sync" keystone
-  args:
-    warn: false
 
 - name: init keystone token provider
   shell: |

--- a/roles/magnum/handlers/main.yml
+++ b/roles/magnum/handlers/main.yml
@@ -1,7 +1,5 @@
 - name: init magnum db
   shell: su -s /bin/sh -c "magnum-db-manage upgrade" magnum
-  args:
-    warn: false
 
 - name: restart magnum-api
   systemd:

--- a/roles/neutron/handlers/main.yml
+++ b/roles/neutron/handlers/main.yml
@@ -2,8 +2,6 @@
   shell: |
     su -s /bin/sh -c "neutron-db-manage --config-file /etc/neutron/neutron.conf \
       --config-file /etc/neutron/plugins/ml2/ml2_conf.ini upgrade head" neutron
-  args:
-    warn: false
   when: is_controller_node
 
 - name: restart neutron-server

--- a/roles/nova/handlers/main.yml
+++ b/roles/nova/handlers/main.yml
@@ -5,14 +5,10 @@
     su -s /bin/sh -c "nova-manage cell_v2 map_cell0" nova
     su -s /bin/sh -c "if ! nova-manage cell_v2 list_cells | grep -q cell1; then nova-manage cell_v2 create_cell --name=cell1; fi" nova
     su -s /bin/sh -c "nova-manage db sync" nova
-  args:
-    warn: false
   when: is_controller_node
 
 - name: discover nova hosts
   shell: su -s /bin/sh -c "nova-manage cell_v2 discover_hosts" nova
-  args:
-    warn: false
   when: is_controller_node
 
 - name: restart nova-api
@@ -49,5 +45,3 @@
   shell: |
     virsh secret-define --file /etc/ceph/libvirt_nova_ceph.xml
     virsh secret-set-value --secret {{nova_rbd_secret_uuid}} --base64 {{nova_rbd_client_key.content | b64decode | regex_search('[A-Za-z0-9\/+]+==', multiline=True)}}
-  args:
-    warn: false

--- a/roles/octavia/handlers/main.yml
+++ b/roles/octavia/handlers/main.yml
@@ -1,7 +1,5 @@
 - name: init octavia db
   shell: su -s /bin/sh -c "octavia-db-manage upgrade head" octavia
-  args:
-    warn: false
   when: is_controller_node
 
 - name: restart octavia-api

--- a/roles/placement/handlers/main.yml
+++ b/roles/placement/handlers/main.yml
@@ -1,4 +1,2 @@
 - name: init placement db
   shell: su -s /bin/sh -c "placement-manage db sync" placement
-  args:
-    warn: false

--- a/roles/trove/handlers/main.yml
+++ b/roles/trove/handlers/main.yml
@@ -1,7 +1,5 @@
 - name: init trove db
   shell: su -s /bin/sh -c "trove-manage db_sync" trove
-  args:
-    warn: false
 
 - name: restart trove-api
   systemd:


### PR DESCRIPTION
The argument warn is deprecated and removed in ansible 2.14.