### PR TITLE
feat: add certificate auth for nova-novnc-proxy and qemu

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ ansible localhost -m template -a "src=secrets.yml.j2 dest=secrets.yml"
 
 Next create certificate authority and save the key at `/etc/openstack-ca/private/ca.key`
 and the certificate at `/etc/openstack-ca/certs/ca.crt` on the ca node. This can be done manually or
-with the `copy_ca.yml` playbook. Remember to use the password from `secrets_ca_key_pass` to encrypt the key.
+with the `copy_ca.yml` playbook. Remember to use the passphrase from `secrets_ca_key_pass` to encrypt the key.
 
 ```sh
 ansible-playbook copy_ca.yml --extra-vars "ca_cert_path=./my-ca.crt ca_key_path=./my-ca.key"

--- a/roles/ca/defaults/main.yml
+++ b/roles/ca/defaults/main.yml
@@ -1,6 +1,6 @@
 ca_dir: /etc/pki/openstack
 ca_key_path: "{{ca_dir}}/private/ca.key"
-ca_key_password: "{{secrets_ca_key_pass}}"
+ca_key_passphrase: "{{secrets_ca_key_pass}}"
 ca_cert_path: "{{ca_dir}}/certs/ca.crt"
 ca_ssl_dir: /etc/pki/tls
 ca_install_trust: false

--- a/roles/ca/tasks/create_ca.yml
+++ b/roles/ca/tasks/create_ca.yml
@@ -18,7 +18,7 @@
 - name: init ca
   shell: |
     /usr/local/bin/cfssl gencert -initca ca.json | /usr/local/bin/cfssljson -bare ca -
-    openssl ec -aes256 -in ca-key.pem -out private/ca.key -passout pass:{{octavia_amphora_ca_key_passphrase}}
+    openssl ec -aes256 -in ca-key.pem -out private/ca.key -passout pass:{{ca_key_passphrase}}
     mv ca.pem certs/ca.crt
     rm ca-key.pem
   args:

--- a/roles/ca/tasks/req_cert.yml
+++ b/roles/ca/tasks/req_cert.yml
@@ -45,7 +45,7 @@
       provider: ownca
       selfsigned_not_after: +720d
       ownca_path: "{{ca_cert_path}}"
-      ownca_privatekey_passphrase: "{{ca_key_password}}"
+      ownca_privatekey_passphrase: "{{ca_key_passphrase}}"
       ownca_privatekey_path: "{{ca_key_path}}"
     delegate_to: "{{ca_host}}"
 

--- a/roles/ca/tasks/request_cert.yml
+++ b/roles/ca/tasks/request_cert.yml
@@ -1,0 +1,128 @@
+# this can be called by other roles to create their certificates
+# following variables must be defined:
+#   req_name
+#   req_common_name
+#   req_owner (defaults to req_name)
+#   req_group (defaults to req_name)
+#   req_post_command (defaults to null)
+#   req_notify (defaults to null)
+#   req_subject_alt_name (defaults to null)
+#   req_create_bundle (defaults to False) - creates a combined private key and certificate file
+#   req_override_privatekey_path (optional)
+#   req_override_cert_path (optional)
+#   req_override_bundle_path (optional)
+#   req_override_ca_cert_path (optional)
+
+- vars:
+    default_privatekey_path: "{{ca_dir}}/private/{{req_common_name}}_{{req_name}}.key"
+    default_csr_path: "{{ca_dir}}/csr/{{req_common_name}}_{{req_name}}.csr"
+    default_cert_path: "{{ca_dir}}/certs/{{req_common_name}}_{{req_name}}.crt"
+    default_bundle_path: "{{ca_dir}}/certs/{{req_common_name}}_{{req_name}}.bundle"
+    privatekey_path: "{{req_override_privatekey_path | default(default_privatekey_path)}}"
+    csr_path: "{{(req_override_cert_path + '.csr') if req_override_cert_path is defined else default_csr_path}}"
+    cert_path: "{{req_override_cert_path | default(default_cert_path)}}"
+    bundle_path: "{{req_override_bundle_path | default(default_bundle_path)}}"
+    ca_cert_path: "{{ca_dir}}/certs/ca.crt"
+    fact_key: "{{req_fact_key | default(((ca_dir | basename) + '_' + req_name) | replace('-', '_'))}}"
+  block:
+    - name: "create private key for {{req_name}}"
+      openssl_privatekey:
+        path: "{{privatekey_path}}"
+        type: RSA
+        size: 4096
+        owner: "{{req_owner | default(req_name)}}"
+        group: "{{req_group | default(req_name)}}"
+        mode: 0600
+      notify: "{{req_notify | default(null)}}"
+
+    - name: "create certificate signing request for {{req_name}}"
+      openssl_csr:
+        path: "{{csr_path}}"
+        privatekey_path: "{{privatekey_path}}"
+        common_name: "{{req_common_name}}"
+        country_name: "{{ca_country_name}}"
+        organization_name: "{{ca_organization_name}}"
+        organizational_unit_name: "{{ca_organization_unit_name}} {{req_name}}"
+        email_address: "{{ca_email_address}}"
+        subject_alt_name: "{{req_subject_alt_name | default([])}}"
+
+    - name: "fetch certificate signing request for {{req_name}}"
+      slurp:
+        path: "{{csr_path}}"
+      register: req_csr
+
+    - name: "upload certificate signing request for {{req_name}}"
+      copy:
+        content: "{{req_csr.content | b64decode}}"
+        dest: "{{ca_dir}}/csr/{{req_common_name}}_{{req_name}}.csr"
+      delegate_to: "{{ca_host}}"
+
+    - name: "create certificate for {{req_name}}"
+      openssl_certificate:
+        path: "{{ca_dir}}/certs/{{req_common_name}}_{{req_name}}.crt"
+        csr_path: "{{ca_dir}}/csr/{{req_common_name}}_{{req_name}}.csr"
+        provider: ownca
+        selfsigned_not_after: +720d
+        ownca_path: "{{ca_cert_path}}"
+        ownca_privatekey_passphrase: "{{ca_key_passphrase}}"
+        ownca_privatekey_path: "{{ca_key_path}}"
+      delegate_to: "{{ca_host}}"
+
+    - name: "fetch certificate for {{req_name}}"
+      slurp:
+        path: "{{ca_dir}}/certs/{{req_common_name}}_{{req_name}}.crt"
+      register: req_cert
+      delegate_to: "{{ca_host}}"
+
+    - name: "upload certificate for {{req_name}}"
+      copy:
+        content: "{{req_cert.content | b64decode}}"
+        dest: "{{cert_path}}"
+        owner: "{{req_owner | default(req_name)}}"
+        group: "{{req_group | default(req_name)}}"
+      notify: "{{req_notify | default(null)}}"
+
+    - name: "fetch ca certificate for {{req_name}}"
+      slurp:
+        path: "{{ca_cert_path}}"
+      register: req_ca_cert
+      when: req_override_ca_cert_path is defined
+      delegate_to: "{{ca_host}}"
+
+    - name: "upload ca certificate for {{req_name}}"
+      copy:
+        content: "{{req_ca_cert.content | b64decode}}"
+        dest: "{{req_override_ca_cert_path}}"
+        owner: root
+        group: root
+      when: req_override_ca_cert_path is defined
+      notify: "{{req_notify | default(null)}}"
+
+    - name: "fetch private key for {{req_name}}"
+      slurp:
+        path: "{{privatekey_path}}"
+      register: req_privatekey
+      when: req_create_bundle | default(false)
+
+    - name: "create certificate bundle for {{req_name}}"
+      copy:
+        content: |
+          {{req_privatekey.content | b64decode}}
+          {{req_cert.content | b64decode}}
+        dest: "{{bundle_path}}"
+        owner: "{{req_owner | default(req_name)}}"
+        group: "{{req_group | default(req_name)}}"
+        mode: 0600
+      when: req_create_bundle | default(false)
+
+    - name: "set facts for {{req_name}}"
+      set_fact:
+        {
+          "{{fact_key}}":
+            {
+              "privatekey_path": "{{privatekey_path}}",
+              "cert_path": "{{cert_path}}",
+              "bundle_path": "{{bundle_path}}",
+              "ca_cert_path": "{{ca_cert_path}}",
+            },
+        }

--- a/roles/nova/defaults/main.yml
+++ b/roles/nova/defaults/main.yml
@@ -46,6 +46,10 @@ nova_sriov_devices: []
   # - devname: eth1
   #   physical_network: net1
   #   trusted: false
+nova_libvirt_vnc_tls: false
+nova_libvirt_vnc_ca_dir: /etc/pki/libvirt-vnc
+nova_libvirt_vnc_ca_key_passphrase: "{{secrets_nova_libvirt_vnc_ca_key_pass}}"
+nova_vnc_auth_schemes: ["{{'vencrypt' if nova_libvirt_vnc_tls else 'none'}}"]
 
 nova_url: "http://{{ansible_nodename}}:8774"
 nova_novnc_url: "https://{{ansible_nodename}}:6080"

--- a/roles/nova/handlers/main.yml
+++ b/roles/nova/handlers/main.yml
@@ -41,6 +41,12 @@
     state: restarted
   when: is_compute_node
 
+- name: restart libvirtd
+  systemd:
+    name: libvirtd
+    state: restarted
+  when: is_compute_node
+
 - name: define nova ceph secret
   shell: |
     virsh secret-define --file /etc/ceph/libvirt_nova_ceph.xml

--- a/roles/nova/tasks/controller.yml
+++ b/roles/nova/tasks/controller.yml
@@ -61,3 +61,30 @@
     req_group: nova
     req_post_command: systemctl restart openstack-nova-novncproxy
     req_notify: restart nova-novncproxy
+
+- name: create libvirt-vnc ca
+  include_role:
+    name: ca
+    tasks_from: create_ca.yml
+  vars:
+    ca_dir: "{{nova_libvirt_vnc_ca_dir}}"
+    ca_organization_unit_name: libvirt VNC
+    ca_owner: root
+    ca_key_passphrase: "{{nova_libvirt_vnc_ca_key_passphrase}}"
+  when: nova_libvirt_vnc_tls
+
+- name: request libvirt-vnc certificate for nova-novnc
+  include_role:
+    name: ca
+    tasks_from: request_cert.yml
+  vars:
+    ca_dir: "{{nova_libvirt_vnc_ca_dir}}"
+    ca_organization_unit_name: libvirt VNC
+    ca_key_passphrase: "{{nova_libvirt_vnc_ca_key_passphrase}}"
+    req_name: nova-novnc
+    req_common_name: "{{ansible_nodename}}"
+    req_owner: nova
+    req_group: nova
+    req_post_command: systemctl restart openstack-nova-novncproxy
+    req_notify: restart nova-novncproxy
+  when: nova_libvirt_vnc_tls

--- a/roles/nova/tasks/main.yml
+++ b/roles/nova/tasks/main.yml
@@ -34,6 +34,41 @@
   when: "is_compute_node
         and nova_ephemeral_storage_backend == 'rbd'"
 
+- name: create libvirt-vnc ca directory
+  file:
+    name: "{{nova_libvirt_vnc_ca_dir}}"
+    state: directory
+  when: "is_compute_node
+        and nova_libvirt_vnc_tls"
+
+- name: request libvirt-vnc certificates for qemu
+  include_role:
+    name: ca
+    tasks_from: request_cert.yml
+  vars:
+    ca_dir: "{{nova_libvirt_vnc_ca_dir}}"
+    ca_organization_unit_name: libvirt VNC
+    ca_key_passphrase: "{{nova_libvirt_vnc_ca_key_passphrase}}"
+    req_name: qemu
+    req_common_name: "{{ansible_nodename}}"
+    req_owner: qemu
+    req_group: qemu
+    req_post_command: systemctl restart libvirtd
+    req_notify: restart libvirtd
+    req_override_privatekey_path: "{{nova_libvirt_vnc_ca_dir}}/server-key.pem"
+    req_override_cert_path: "{{nova_libvirt_vnc_ca_dir}}/server-cert.pem"
+    req_override_ca_cert_path: "{{nova_libvirt_vnc_ca_dir}}/ca-cert.pem"
+  when: "is_compute_node
+        and nova_libvirt_vnc_tls"
+
+- name: configure qemu
+  template:
+    src: qemu.conf.j2
+    dest: /etc/libvirt/qemu.conf
+    backup: true
+  when: is_compute_node
+  notify: restart libvirtd
+
 - name: enable migrations
   include_tasks: migrations.yml
   args:

--- a/roles/nova/templates/nova.conf.j2
+++ b/roles/nova/templates/nova.conf.j2
@@ -104,6 +104,12 @@ enabled = true
 server_proxyclient_address = $my_ip
 {% if is_controller_node %}
 server_listen = $my_ip
+{% if nova_libvirt_vnc_tls %}
+vencrypt_client_key = {{libvirt_vnc_nova_novnc.privatekey_path}}
+vencrypt_client_cert = {{libvirt_vnc_nova_novnc.cert_path}}
+vencrypt_ca_certs = {{libvirt_vnc_nova_novnc.ca_cert_path}}
+auth_schemes = {{nova_vnc_auth_schemes | join(',')}}
+{% endif %}
 {% endif %}
 {% if is_compute_node %}
 novncproxy_base_url = {{nova_novnc_url}}/vnc_auto.html

--- a/roles/nova/templates/qemu.conf.j2
+++ b/roles/nova/templates/qemu.conf.j2
@@ -1,0 +1,7 @@
+# {{ansible_managed}}
+
+{% if nova_libvirt_vnc_tls %}
+vnc_tls = 1
+vnc_tls_x509_cert_dir = "{{nova_libvirt_vnc_ca_dir}}"
+vnc_tls_x509_verify = 1
+{% endif %}

--- a/secrets.yml.j2
+++ b/secrets.yml.j2
@@ -1,4 +1,4 @@
-# Password for CA private key
+# Passphrase for CA private key
 secrets_ca_key_pass: "{{ secrets_ca_key_pass | default(lookup('password', '/dev/null chars=ascii_letters,digits')) }}"
 # Root password for the database
 secrets_db_root_pass: "{{ secrets_db_root_pass | default(lookup('password', '/dev/null chars=ascii_letters,digits')) }}"
@@ -30,6 +30,8 @@ secrets_neutron_pass: "{{ secrets_neutron_pass | default(lookup('password', '/de
 secrets_nova_dbpass: "{{ secrets_nova_dbpass | default(lookup('password', '/dev/null chars=ascii_letters,digits')) }}"
 # Password of Compute service user nova
 secrets_nova_pass: "{{ secrets_nova_pass | default(lookup('password', '/dev/null chars=ascii_letters,digits')) }}"
+# Passphrase for libvirt-vnc ca key
+secrets_nova_libvirt_vnc_ca_key_pass: "{{ secrets_nova_libvirt_vnc_ca_key_pass | default(lookup('password', '/dev/null chars=ascii_letters,digits')) }}"
 # Database password for Placement service
 secrets_placement_dbpass: "{{ secrets_placement_dbpass | default(lookup('password', '/dev/null chars=ascii_letters,digits')) }}"
 # Password of the Placement service user placement


### PR DESCRIPTION
This PR adds optional certificate based authentication and encryption for the communication between the nova-novnc-proxy and QEMU (see [remote-console-access.html#vnc-proxy-security](https://docs.openstack.org/nova/queens/admin/remote-console-access.html#vnc-proxy-security)).
By default this connection is still not authenticated or encrypted, so the VNC ports can be accessed by everyone with access to the compute node IPs.